### PR TITLE
Buf fix for simplification of image name for csv ouput 

### DIFF
--- a/computeDerenzoValleyToPeak.py
+++ b/computeDerenzoValleyToPeak.py
@@ -1166,8 +1166,8 @@ def simplifyImagesName(_imName):
 	
 	if tmp != "":
 		for i in range(len(_imName)):
-			_imName[i] = _imName[i].lstrip(redondantPart)
-	
+			_imName[i] = _imName[i][len(redondantPart):]
+
 	return _imName
 
 


### PR DESCRIPTION
This is a quick fix for the part that attempt to simplify the image name. In short, lstrip was not the good call for simplify!

In python==3.9, we could use removeprefix but making 3.9 mandatory for that is too much.